### PR TITLE
Fix support for passwords with spaces and quotes

### DIFF
--- a/downloadGUI.cs
+++ b/downloadGUI.cs
@@ -76,7 +76,7 @@ namespace DepotDownloaderGUI
                     //IIf a password is entered, add it to the args
                     if (textBoxPassword.Text.Length > 0)
                     {
-                        Command += $" -password { textBoxPassword.Text}";
+                        Command += $" -password '{textBoxPassword.Text.Replace("'", "\\'")}'";
                     }
                     //Note: remember password only works if a username is entered.
                     if (textBoxUsername.Text.Length > 0 & ChooseBox_PSW != null & !textBoxArgs.Text.Contains("-remember-password") & textBoxPassword.Text.Length <= 0)


### PR DESCRIPTION
I tried the tool and it didn't work for me because my password contains spaces and/or quotes.

By wrapping the password in single quotes and then escaping any single quotes, it should now support passwords with spaces and quotes.

I wasn't able to build the project on my own machine (did this edit in the web browser) so I'd suggest testing it. If you make a build I'd be happy to try it out as well.