### PR TITLE
Size the window with respect to the window's frame size

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const createWindow = () => {
 		resizable: false,
 		width: 430,
 		height: 590,
+		useContentSize: true,
 		maximizable: false,
 		webPreferences: {
 			nodeIntegration: true,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/53093333/197341882-f71613b8-076b-4912-bec3-b9471af839fe.png)
After:
![image](https://user-images.githubusercontent.com/53093333/197341895-e97b10aa-1caf-451e-bec9-8073f998cef8.png)

Fixes an issue where, at least for me, the window will have the wrong height and will therefore have a scrollbar.
[According to the electron documentation](https://www.electronjs.org/docs/latest/api/browser-window#class-browserwindow) `useContentSize` will take the size of the top window frame bar and add it to the height of the actual window, while the webpages size will just use the `width` and `height` properties as defined.
Strange this wasn't noticed before, maybe it's not a problem on Linux? I'm using a 1440p monitor and Windows 10.