### PR TITLE
replace tooltips with placeholder when information is needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,45 +43,35 @@
 			<div class="form-group-header">
 				<label for="username">Username</label>
 			</div>
-			<div aria-label="Enter your username here. (leave empty for anonymous login)" class="form-group-body tooltipped tooltipped-n">
-				<input class="form-control input-block" id="username" type="text"/>
-			</div>
+			<input class="form-control input-block" id="username" type="text" placeholder="Leave empty for anonymous login"/>
 		</div>
 
 		<div class="form-group mx-3 mt-1">
 			<div class="form-group-header">
 				<label for="password">Password</label>
 			</div>
-			<div aria-label="Enter your password here. (leave empty for anonymous login)" class="form-group-body tooltipped tooltipped-n">
-				<input class="form-control input-block" id="password" type="password"/>
-			</div>
+			<input class="form-control input-block" id="password" type="password" placeholder="Leave empty for anonymous login"/>
 		</div>
 
 		<div class="form-group mx-3 mt-1">
 			<div class="form-group-header">
 				<label for="appid">App ID</label>
 			</div>
-			<div aria-label="Enter the App ID here." class="form-group-body tooltipped tooltipped-n">
-				<input class="form-control input-block" id="appid" type="number"/>
-			</div>
+			<input class="form-control input-block" id="appid" type="number"/>
 		</div>
 
 		<div class="form-group mx-3 mt-1">
 			<div class="form-group-header">
 				<label for="depotid">Depot ID</label>
 			</div>
-			<div aria-label="Enter the Depot ID here." class="form-group-body tooltipped tooltipped-n">
-				<input class="form-control input-block" id="depotid" type="number"/>
-			</div>
+			<input class="form-control input-block" id="depotid" type="number"/>
 		</div>
 
 		<div class="form-group mx-3 mt-1">
 			<div class="form-group-header">
 				<label for="manifestid">Manifest ID</label>
 			</div>
-			<div aria-label="Enter the Manifest ID here." class="form-group-body tooltipped tooltipped-n">
-				<input class="form-control input-block" id="manifestid" type="number"/>
-			</div>
+			<input class="form-control input-block" id="manifestid" type="number"/>
 		</div>
 
 		<div class="form-group mx-3 mt-1">
@@ -106,7 +96,7 @@
 		</div>
 	</form>
 
-	<div aria-label="Start the download process." class="form-group mt-3 ml-3 mr-3 tooltipped tooltipped-n">
+	<div class="form-group mt-3 ml-3 mr-3">
 		<button class="btn btn-block btn-primary" id="downloadbtn">
 			<svg class="octicon" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
 				<path d="M7.47 10.78a.75.75 0 001.06 0l3.75-3.75a.75.75 0 00-1.06-1.06L8.75 8.44V1.75a.75.75 0 00-1.5 0v6.69L4.78 5.97a.75.75 0 00-1.06 1.06l3.75 3.75zM3.75 13a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5z"


### PR DESCRIPTION
Works on #42
![image](https://user-images.githubusercontent.com/53093333/197396597-e0c7f593-6bab-478b-9681-cccd50e910f1.png)
Motivation:
The tooltips were not that descriptive before, so I removed some of them. For example, the `Enter the App ID here` tooltip was self-explanatory because the input's label is `App ID`.
The tooltips also kind of gets in the way and are distracting, which is frustrating when they are not necessary. When the user moves their mouse to click on the App ID input field, they already know that the field is meant for putting the App ID in, they don't need a popup to display that.
For the first two input fields, username and password, I thought that it's probably better to use a placeholder text since it's counterintuitive to have to hover over the fields.
I did keep the tooltips on `support`, `SteamDB`, and `Operating system` though, because I thought the tooltips provided more information there.
Any complaints or feedback or suggestions?